### PR TITLE
removing advanced search

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 - **OpenAPI specification:** [openapi.yaml](openapi.yaml)
 - **Conformance Classes:**
   - <https://api.stacspec.org/v1.0.0-rc.1/item-search#free-text>
-  - <https://api.stacspec.org/v1.0.0-rc.1/item-search#advanced-free-text>
   - <https://api.stacspec.org/v1.0.0-rc.1/collection-search#free-text>
-  - <https://api.stacspec.org/v1.0.0-rc.1/collection-search#advanced-free-text>
   - <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#free-text>
-  - <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#advanced-free-text>
 - **Scope:**
   - STAC API - Collection Search
   - STAC API - Item Search
@@ -29,18 +26,13 @@ but a recommendation is to at least consider:
 - Item: all relevant textual properties
 It is also allowed to query against all text fields.
 
-This extension sits somewhere between the basic API and the [Filter Extension](https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter) providing
+This extension sits somewhere between the basic API and the [Filter Extension](https://github.com/stac-api-extensions/filter) providing
 more powerful query features than the raw API but without the flexibility and increased operators of the filter plugin. This should mostly be used to provide
 the ability to search for keywords across all properties with more complex queries and faceted search being provided by the filter extension.
 
-This extension defines two flavors of free text search. 
-A simple one that is aligned with [OGC API - Records](https://docs.ogc.org/DRAFTS/20-004.html#_parameter_q) and 
-a more advanced one.
-Both variants can be implemented against any of the search endpoints (Collection Search, Item Search, Features).
+This extension is aligned with [OGC API - Records](https://docs.ogc.org/DRAFTS/20-004.html#_parameter_q) and can be implemented against any of the search endpoints (Collection Search, Item Search, Features).
 
-## Basic
-
-### HTTP GET / POST
+## HTTP GET / POST
 
 **Conformance Classes:**
   - Item Search (global): <https://api.stacspec.org/v1.0.0-rc.1/item-search#free-text>
@@ -55,40 +47,3 @@ Any of the search terms must be present in the set of text fields (OR operaror).
 
 - In HTTP `GET` requests, all search terms must be separated by a comma. For example, if you want to search for "Earth Observation" or "EO", your query parameter should be as follows: `q=EO,Earth Observation`.
 - In HTTP `POST` requests, an array of search terms must be provided, for example: `{"q": ["EO", "Earth Observation"]}`.
-
-## Advanced
-
-**Conformance Classes:**
-  - Item Search (global): <https://api.stacspec.org/v1.0.0-rc.1/item-search#advanced-free-text>
-  - Collection Search: <https://api.stacspec.org/v1.0.0-rc.1/collection-search#advanced-free-text>
-  - Features (item search per collection): <https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features#advanced-free-text>
-
-**OpenAPI document:** [openapi.yaml](openapi.yaml)
-
-### HTTP GET
-
-**Examples:**
-
-| URL Example | Summary | Detail |
-| ----------- | ------- | ------ |
-| `/search?q=sentinel` | Free-text query against all properties | This will search for any matching items that CONTAIN `"sentinel"` |
-| `/search?q="climate model"` | Free-text search using exact | This will search for any matching items that CONTAIN the exact phrase `"climate model"` |
-|`/search?q=climate model`| Using `OR` term match (**Default**) | This will search for any matching items that CONTAIN `"climate"` OR `"model"`|
-|`/search?q=climate OR model`| Using `OR` term match (**Default**) | This will search for any matching items that CONTAIN `"climate"` OR `"model"`|
-|`/search?q=climate AND model`| Using `AND` term match | This will search for any matching items that CONTAIN `"climate"` AND `"model"`|
-| `/search?q=(quick OR brown) AND fox` | Parentheses can be used to group terms | This will search for matching items that CONTAIN `"quick"` OR `"brown"` AND `"fox"` |
-| `/search?q=quick +brown -fox` | Indicate included and excluded terms using `+`/`-` | This will search for items that INCLUDES `"brown"` EXCLUDES `"fox"` OR CONTAIN `"quick"` |
-
-### HTTP POST
-
-When calling the relevant endpoint using `POST` with `Content-Type: application/json`, this adds an attribute `q` with an object value to the core JSON search request body.
-
-The syntax for the q attribute is:
-
-```json
-{
-  "q": "your query string"
-}
-```
-
-See [examples](#examples) section for more complex queries

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13,11 +13,39 @@
     "url" : "https://virtserver.swaggerhub.com/cedadev/free-text/1.0.0",
     "description" : "SwaggerHub API Auto Mocking"
   } ],
-  "paths" : { },
+  "paths" : {
+    "/search": {
+      "get": {
+        "parameters": [
+          "$ref": '#/components/parameters/q'
+        ]
+      }
+    }
+  },
   "components" : {
+    "parameters": {
+      "q" : {
+        "name" : "q",
+        "in" : "query",
+        "description" : "**Optional Extension:** Free Text\n\nMake free-text queries against properties in items.\nUse the JSON form of the query used in POST.",
+        "required" : false,
+        "allowEmptyValue" : true,
+        "style" : "form",
+        "explode" : false,
+        "schema" : {
+          "type" : "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "schemas" : {
       "searchBody" : {
         "type" : "object",
+        "allOf": [
+          "$ref": "https://api.stacspec.org/v1.0.0/item-search/openapi.yaml#/components/schemas/searchBody"
+        ],
         "properties" : {
           "q" : {
             "$ref" : "#/components/schemas/q"
@@ -29,21 +57,6 @@
         "type" : "string",
         "description" : "Search string",
         "example" : "HadGem"
-      }
-    },
-    "parameters" : {
-      "q" : {
-        "name" : "q",
-        "in" : "query",
-        "description" : "**Optional Extension:** Free Text\n\nMake free-text queries against properties in items.\nUse the JSON form of the query used in POST.",
-        "required" : false,
-        "allowEmptyValue" : true,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string",
-          "example" : "HadGem3"
-        }
       }
     }
   }


### PR DESCRIPTION
Advanced and simple free text search are not compatible. I think advanced search is closer to [Filter Extension](https://github.com/stac-api-extensions/filter) so should be moved to either the filter extension or it's own extension of the filter extension.

#10 


